### PR TITLE
fix: remove dead instrument.ts reference from backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ COPY prisma.config.ts ./
 RUN npx prisma generate
 
 FROM common AS build
-COPY nest-cli.json instrument.ts ./
+COPY nest-cli.json ./
 COPY src ./src
 RUN npx nest build
 


### PR DESCRIPTION
## Problème

Le `backend/Dockerfile` copie `instrument.ts` dans le stage `build` (`COPY nest-cli.json instrument.ts ./`), mais ce fichier **n'existe plus** dans le repo et **n'est importé nulle part** (l'instrumentation Sentry passe désormais par `SentryModule.forRoot()` dans `app.module.ts`).

Conséquence : le build échoue (`"/instrument.ts": not found`) dès qu'on cible le stage `build` — c'est-à-dire le service `logs-sink` et le build de production (`runner`), ainsi que la CI.

## Correction

Retrait de la référence morte : `COPY nest-cli.json instrument.ts ./` → `COPY nest-cli.json ./`.

## Vérification

- `docker compose build logs-sink` passe désormais.
- `docker compose up` complet fonctionne.