### PR TITLE
feat(#59): add signin page with email/password form

### DIFF
--- a/clientApp/src/features/onboarding/pages/SigninPage.tsx
+++ b/clientApp/src/features/onboarding/pages/SigninPage.tsx
@@ -1,0 +1,94 @@
+import { useState, type FormEvent } from 'react';
+import { ChevronLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface SigninPageProps {
+  onBack?: () => void;
+  onSignUp?: () => void;
+  onSubmit?: (data: { email: string; password: string }) => void;
+}
+
+export function SigninPage({ onBack, onSignUp, onSubmit }: SigninPageProps) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    onSubmit?.({ email, password });
+  }
+
+  return (
+    <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col bg-background px-6 pt-4 pb-8">
+      <header className="relative flex h-9 items-center justify-center">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Retour"
+          className="absolute left-0 flex size-9 cursor-pointer items-center justify-center rounded-full bg-card text-ink shadow-sm transition-colors hover:bg-muted"
+        >
+          <ChevronLeft className="size-5" />
+        </button>
+        <h1 className="font-heading text-base font-bold text-ink">Connexion</h1>
+      </header>
+
+      <div className="mt-10 flex flex-col gap-1.5">
+        <h2 className="font-heading text-2xl font-bold text-ink">Heureux de te revoir.</h2>
+        <p className="text-sm text-ink-muted">Connecte-toi pour reprendre tes matches.</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="mt-8 flex flex-col gap-5">
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="signin-email" className="text-xs text-ink-muted">
+            Email
+          </label>
+          <Input
+            id="signin-email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="ton@email.com"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="signin-password" className="text-xs text-ink-muted">
+            Mot de passe
+          </label>
+          <Input
+            id="signin-password"
+            type="password"
+            autoComplete="current-password"
+            required
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            placeholder="Ton mot de passe"
+          />
+        </div>
+
+        <Button type="submit" variant="role" size="xl" className="mt-1 w-full">
+          Se connecter
+        </Button>
+      </form>
+
+      <div className="mt-8 flex items-center gap-4" aria-hidden="true">
+        <span className="h-px flex-1 bg-line" />
+        <span className="text-xs text-ink-faint">ou</span>
+        <span className="h-px flex-1 bg-line" />
+      </div>
+
+      <p className="mt-6 flex items-center justify-center gap-1.5 text-sm text-ink-muted">
+        Pas encore de compte ?
+        <button
+          type="button"
+          onClick={onSignUp}
+          className="cursor-pointer font-medium text-role-strong hover:underline"
+        >
+          Inscription
+        </button>
+      </p>
+    </main>
+  );
+}

--- a/clientApp/src/features/onboarding/routes.tsx
+++ b/clientApp/src/features/onboarding/routes.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router';
 import { SplashPage } from '@/features/onboarding/pages/SplashPage';
 import { SignupPage } from '@/features/onboarding/pages/SignupPage';
+import { SigninPage } from '@/features/onboarding/pages/SigninPage';
 
 export function SplashRoute() {
   const navigate = useNavigate();
@@ -15,4 +16,9 @@ export function SplashRoute() {
 export function SignupRoute() {
   const navigate = useNavigate();
   return <SignupPage onBack={() => navigate('/')} onSignIn={() => navigate('/connexion')} />;
+}
+
+export function SigninRoute() {
+  const navigate = useNavigate();
+  return <SigninPage onBack={() => navigate('/')} onSignUp={() => navigate('/inscription')} />;
 }

--- a/clientApp/src/router.tsx
+++ b/clientApp/src/router.tsx
@@ -1,8 +1,9 @@
 import { createBrowserRouter, Navigate } from 'react-router';
-import { SplashRoute, SignupRoute } from '@/features/onboarding/routes';
+import { SplashRoute, SignupRoute, SigninRoute } from '@/features/onboarding/routes';
 
 export const router = createBrowserRouter([
   { path: '/', element: <SplashRoute /> },
   { path: '/inscription', element: <SignupRoute /> },
+  { path: '/connexion', element: <SigninRoute /> },
   { path: '*', element: <Navigate to="/" replace /> },
 ]);


### PR DESCRIPTION
## Summary

Ajoute la **page de connexion** (maquette Penpot M9) et sa route `/connexion`, en réutilisant la structure et le design system de la page d'inscription (#58).

## Why

Écran du parcours d'onboarding pour un utilisateur déjà inscrit (Splash → Inscription / Connexion). Complète au passage un lien qui pendait : le CTA « Se connecter » du Splash pointait vers `/connexion`, jusqu'ici absent du routeur (fallback → `/`).

## How

- **SigninPage** (`features/onboarding/pages/SigninPage.tsx`) : header (retour + titre centré), accroche « Heureux de te revoir. », champs email / mot de passe (validation front native : `type="email"` + `required`, `autoComplete` adaptés `email` / `current-password`), séparateur « ou » décoratif (`aria-hidden`), lien vers l'inscription. Page présentationnelle (callbacks `onBack` / `onSignUp` / `onSubmit`).
- **Routing** (`router.tsx` + `features/onboarding/routes.tsx`) : ajout de la route `/connexion` (avant le catch-all) et de `SigninRoute` (`onBack` → `/`, `onSignUp` → `/inscription`).
- **Design system** : aucune nouvelle primitive — réutilise `Input`, la variante Button `role` et les tokens existants. Hors contexte `data-role`, les tokens `role` retombent sur l'accent marque (vert), défaut adapté à un écran où le rôle est encore inconnu.

## User Story

En tant qu'utilisateur déjà inscrit, je veux me connecter via un écran dédié, afin d'accéder à mon compte. — issue #59
