### PR TITLE
feat(#60): add forgot password page with inline success

### DIFF
--- a/clientApp/src/features/onboarding/pages/ForgotPasswordPage.tsx
+++ b/clientApp/src/features/onboarding/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState, type FormEvent } from 'react';
+import { ChevronLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface ForgotPasswordPageProps {
+  onBack?: () => void;
+  onSignIn?: () => void;
+  onSubmit?: (data: { email: string }) => void;
+}
+
+export function ForgotPasswordPage({ onBack, onSignIn, onSubmit }: ForgotPasswordPageProps) {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const successHeadingRef = useRef<HTMLHeadingElement>(null);
+
+  // Announce the success state to screen readers on transition.
+  useEffect(() => {
+    if (submitted) {
+      successHeadingRef.current?.focus();
+    }
+  }, [submitted]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmedEmail = email.trim();
+    setEmail(trimmedEmail);
+    onSubmit?.({ email: trimmedEmail });
+    setSubmitted(true);
+  }
+
+  return (
+    <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col bg-background px-6 pt-4 pb-8">
+      <header className="relative flex h-9 items-center justify-center">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Retour"
+          className="absolute left-0 flex size-9 cursor-pointer items-center justify-center rounded-full bg-card text-ink shadow-sm transition-colors hover:bg-muted"
+        >
+          <ChevronLeft className="size-5" />
+        </button>
+        <h1 className="font-heading text-base font-bold text-ink">Mot de passe oublié</h1>
+      </header>
+
+      {submitted ? (
+        <div className="mt-10 flex flex-col gap-1.5" role="status">
+          <h2
+            ref={successHeadingRef}
+            tabIndex={-1}
+            className="font-heading text-2xl font-bold text-ink outline-none"
+          >
+            Email envoyé.
+          </h2>
+          <p className="text-sm text-ink-muted">
+            Si un compte est associé à <span className="font-medium text-ink">{email}</span>, tu
+            reçois un lien pour réinitialiser ton mot de passe. Pense à vérifier tes spams.
+          </p>
+          <button
+            type="button"
+            onClick={() => setSubmitted(false)}
+            className="mt-4 cursor-pointer self-start text-sm font-medium text-role-strong hover:underline"
+          >
+            Modifier l'email
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="mt-10 flex flex-col gap-1.5">
+            <h2 className="font-heading text-2xl font-bold text-ink">Pas de panique.</h2>
+            <p className="text-sm text-ink-muted">
+              Saisis ton email, on t'envoie un lien pour le réinitialiser.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="mt-8 flex flex-col gap-5">
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="forgot-email" className="text-xs text-ink-muted">
+                Email
+              </label>
+              <Input
+                id="forgot-email"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="ton@email.com"
+              />
+            </div>
+
+            <Button type="submit" variant="role" size="xl" className="mt-1 w-full">
+              Envoyer le lien
+            </Button>
+          </form>
+        </>
+      )}
+
+      <p className="mt-8 flex items-center justify-center gap-1.5 text-sm text-ink-muted">
+        Tu t'en souviens ?
+        <button
+          type="button"
+          onClick={onSignIn}
+          className="cursor-pointer font-medium text-role-strong hover:underline"
+        >
+          Connexion
+        </button>
+      </p>
+    </main>
+  );
+}

--- a/clientApp/src/features/onboarding/pages/SigninPage.tsx
+++ b/clientApp/src/features/onboarding/pages/SigninPage.tsx
@@ -6,10 +6,11 @@ import { Input } from '@/components/ui/input';
 interface SigninPageProps {
   onBack?: () => void;
   onSignUp?: () => void;
+  onForgotPassword?: () => void;
   onSubmit?: (data: { email: string; password: string }) => void;
 }
 
-export function SigninPage({ onBack, onSignUp, onSubmit }: SigninPageProps) {
+export function SigninPage({ onBack, onSignUp, onForgotPassword, onSubmit }: SigninPageProps) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
@@ -66,6 +67,13 @@ export function SigninPage({ onBack, onSignUp, onSubmit }: SigninPageProps) {
             onChange={(event) => setPassword(event.target.value)}
             placeholder="Ton mot de passe"
           />
+          <button
+            type="button"
+            onClick={onForgotPassword}
+            className="mt-0.5 cursor-pointer self-end text-xs font-medium text-role-strong hover:underline"
+          >
+            Mot de passe oublié ?
+          </button>
         </div>
 
         <Button type="submit" variant="role" size="xl" className="mt-1 w-full">

--- a/clientApp/src/features/onboarding/routes.tsx
+++ b/clientApp/src/features/onboarding/routes.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router';
 import { SplashPage } from '@/features/onboarding/pages/SplashPage';
 import { SignupPage } from '@/features/onboarding/pages/SignupPage';
 import { SigninPage } from '@/features/onboarding/pages/SigninPage';
+import { ForgotPasswordPage } from '@/features/onboarding/pages/ForgotPasswordPage';
 
 export function SplashRoute() {
   const navigate = useNavigate();
@@ -20,5 +21,21 @@ export function SignupRoute() {
 
 export function SigninRoute() {
   const navigate = useNavigate();
-  return <SigninPage onBack={() => navigate('/')} onSignUp={() => navigate('/inscription')} />;
+  return (
+    <SigninPage
+      onBack={() => navigate('/')}
+      onSignUp={() => navigate('/inscription')}
+      onForgotPassword={() => navigate('/mot-de-passe-oublie')}
+    />
+  );
+}
+
+export function ForgotPasswordRoute() {
+  const navigate = useNavigate();
+  return (
+    <ForgotPasswordPage
+      onBack={() => navigate('/connexion')}
+      onSignIn={() => navigate('/connexion')}
+    />
+  );
 }

--- a/clientApp/src/router.tsx
+++ b/clientApp/src/router.tsx
@@ -1,9 +1,15 @@
 import { createBrowserRouter, Navigate } from 'react-router';
-import { SplashRoute, SignupRoute, SigninRoute } from '@/features/onboarding/routes';
+import {
+  SplashRoute,
+  SignupRoute,
+  SigninRoute,
+  ForgotPasswordRoute,
+} from '@/features/onboarding/routes';
 
 export const router = createBrowserRouter([
   { path: '/', element: <SplashRoute /> },
   { path: '/inscription', element: <SignupRoute /> },
   { path: '/connexion', element: <SigninRoute /> },
+  { path: '/mot-de-passe-oublie', element: <ForgotPasswordRoute /> },
   { path: '*', element: <Navigate to="/" replace /> },
 ]);


### PR DESCRIPTION
## Summary

Ajoute la page **Mot de passe oublié** et sa route `/mot-de-passe-oublie`, en réutilisant la structure et le design system de la page de connexion (#59). Parcours en 1 écran avec **succès inline**.

## Why

Complète le parcours d'onboarding (Splash → Connexion → Mot de passe oublié) pour un utilisateur qui ne peut plus se connecter. Câble au passage un lien qui pendait : le « Mot de passe oublié ? » de la maquette Connexion (M9) n'était pas implémenté dans `SigninPage`.

## How

- **ForgotPasswordPage** (`features/onboarding/pages/ForgotPasswordPage.tsx`) : header (retour + titre centré), accroche « Pas de panique. », un champ email (validation front native `type="email"` + `required`, `autoComplete="email"`), CTA « Envoyer le lien », lien retour vers la connexion. Page présentationnelle (callbacks `onBack` / `onSignIn` / `onSubmit`).
- **Succès inline** : un state `submitted` bascule le formulaire vers un bloc de confirmation neutre (« Si un compte est associé à … » — anti-énumération de comptes), reprenant l'email trimé. A11y : focus déplacé sur le titre de succès (`role="status"`) pour l'annonce lecteur d'écran, lien « Modifier l'email » pour revenir au formulaire pré-rempli.
- **SigninPage** : lien « Mot de passe oublié ? » ajouté sous le champ mot de passe (nouvelle prop `onForgotPassword`).
- **Routing** (`router.tsx` + `features/onboarding/routes.tsx`) : route `/mot-de-passe-oublie` (avant le catch-all) et `ForgotPasswordRoute` ; `SigninRoute` navigue vers cette route via `onForgotPassword`.
- **Design system** : aucune nouvelle primitive — réutilise `Input`, la variante Button `role` et les tokens existants (fallback vert marque hors contexte `data-role`).

## User Story

En tant qu'utilisateur ayant oublié mon mot de passe, je veux demander un lien de réinitialisation via un écran dédié, afin de retrouver l'accès à mon compte. — issue #60