### PR TITLE
feat(#66): extend Prisma schema with profile fields and English naming

### DIFF
--- a/backend/prisma/migrations/20260719194422_add_profile_and_english_naming/migration.sql
+++ b/backend/prisma/migrations/20260719194422_add_profile_and_english_naming/migration.sql
@@ -1,0 +1,116 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `code_postal` on the `candidate_profile` table. All the data in the column will be lost.
+  - You are about to drop the column `nom` on the `candidate_profile` table. All the data in the column will be lost.
+  - You are about to drop the column `prenom` on the `candidate_profile` table. All the data in the column will be lost.
+  - You are about to drop the column `ville` on the `candidate_profile` table. All the data in the column will be lost.
+  - You are about to drop the column `code_postal` on the `company` table. All the data in the column will be lost.
+  - You are about to drop the column `nom` on the `company` table. All the data in the column will be lost.
+  - You are about to drop the column `taille` on the `company` table. All the data in the column will be lost.
+  - You are about to drop the column `ville` on the `company` table. All the data in the column will be lost.
+  - You are about to drop the column `code_postal` on the `offer` table. All the data in the column will be lost.
+  - You are about to drop the column `statut` on the `offer` table. All the data in the column will be lost.
+  - You are about to drop the column `titre` on the `offer` table. All the data in the column will be lost.
+  - You are about to drop the column `ville` on the `offer` table. All the data in the column will be lost.
+  - You are about to drop the column `nom` on the `recruiter_profile` table. All the data in the column will be lost.
+  - You are about to drop the column `prenom` on the `recruiter_profile` table. All the data in the column will be lost.
+  - Added the required column `first_name` to the `candidate_profile` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `last_name` to the `candidate_profile` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `name` to the `company` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `title` to the `offer` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `first_name` to the `recruiter_profile` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `last_name` to the `recruiter_profile` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "contract_type" AS ENUM ('CDI', 'CDD', 'ALTERNANCE', 'STAGE', 'FREELANCE', 'INTERIM');
+
+-- CreateEnum
+CREATE TYPE "experience_level" AS ENUM ('JUNIOR', 'CONFIRME', 'SENIOR', 'EXPERT');
+
+-- CreateEnum
+CREATE TYPE "remote_policy" AS ENUM ('ON_SITE', 'HYBRID', 'FULL_REMOTE');
+
+-- CreateEnum
+CREATE TYPE "availability" AS ENUM ('IMMEDIATE', 'WITHIN_DELAY', 'SPECIFIC_DATE');
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "tag_category" ADD VALUE 'language';
+ALTER TYPE "tag_category" ADD VALUE 'benefit';
+
+-- AlterTable
+ALTER TABLE "candidate_profile" DROP COLUMN "code_postal",
+DROP COLUMN "nom",
+DROP COLUMN "prenom",
+DROP COLUMN "ville",
+ADD COLUMN     "availability" "availability",
+ADD COLUMN     "availability_date" TIMESTAMPTZ(6),
+ADD COLUMN     "availability_delay_months" INTEGER,
+ADD COLUMN     "city" VARCHAR(100),
+ADD COLUMN     "contract_types" "contract_type"[],
+ADD COLUMN     "cv_url" VARCHAR(255),
+ADD COLUMN     "desired_job_title" VARCHAR(255),
+ADD COLUMN     "experience_level" "experience_level",
+ADD COLUMN     "first_name" VARCHAR(100) NOT NULL,
+ADD COLUMN     "last_name" VARCHAR(100) NOT NULL,
+ADD COLUMN     "linkedin_url" VARCHAR(255),
+ADD COLUMN     "mobility_nationwide" BOOLEAN,
+ADD COLUMN     "mobility_radius_km" INTEGER,
+ADD COLUMN     "postal_code" VARCHAR(10),
+ADD COLUMN     "remote_policy" "remote_policy",
+ADD COLUMN     "salary_max" INTEGER,
+ADD COLUMN     "salary_min" INTEGER;
+
+-- AlterTable
+ALTER TABLE "company" DROP COLUMN "code_postal",
+DROP COLUMN "nom",
+DROP COLUMN "taille",
+DROP COLUMN "ville",
+ADD COLUMN     "city" VARCHAR(100),
+ADD COLUMN     "cover_image" VARCHAR(255),
+ADD COLUMN     "name" VARCHAR(255) NOT NULL,
+ADD COLUMN     "postal_code" VARCHAR(10),
+ADD COLUMN     "size" "company_size";
+
+-- AlterTable
+ALTER TABLE "offer" DROP COLUMN "code_postal",
+DROP COLUMN "statut",
+DROP COLUMN "titre",
+DROP COLUMN "ville",
+ADD COLUMN     "city" VARCHAR(100),
+ADD COLUMN     "contract_type" "contract_type",
+ADD COLUMN     "min_experience_level" "experience_level",
+ADD COLUMN     "postal_code" VARCHAR(10),
+ADD COLUMN     "remote_policy" "remote_policy",
+ADD COLUMN     "salary_max" INTEGER,
+ADD COLUMN     "salary_min" INTEGER,
+ADD COLUMN     "status" "offer_status" NOT NULL DEFAULT 'draft',
+ADD COLUMN     "title" VARCHAR(255) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "recruiter_profile" DROP COLUMN "nom",
+DROP COLUMN "prenom",
+ADD COLUMN     "first_name" VARCHAR(100) NOT NULL,
+ADD COLUMN     "last_name" VARCHAR(100) NOT NULL;
+
+-- CreateTable
+CREATE TABLE "company_tag" (
+    "fk_company" INTEGER NOT NULL,
+    "fk_tag" INTEGER NOT NULL,
+
+    CONSTRAINT "company_tag_pkey" PRIMARY KEY ("fk_company","fk_tag")
+);
+
+-- AddForeignKey
+ALTER TABLE "company_tag" ADD CONSTRAINT "company_tag_fk_company_fkey" FOREIGN KEY ("fk_company") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "company_tag" ADD CONSTRAINT "company_tag_fk_tag_fkey" FOREIGN KEY ("fk_tag") REFERENCES "tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260719205910_add_match_table/migration.sql
+++ b/backend/prisma/migrations/20260719205910_add_match_table/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "match" (
+    "id" SERIAL NOT NULL,
+    "fk_user_candidate" INTEGER NOT NULL,
+    "fk_offer" INTEGER NOT NULL,
+    "fk_user_recruiter" INTEGER,
+    "matched_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "match_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "match_fk_user_candidate_fk_offer_key" ON "match"("fk_user_candidate", "fk_offer");
+
+-- AddForeignKey
+ALTER TABLE "match" ADD CONSTRAINT "match_fk_user_candidate_fkey" FOREIGN KEY ("fk_user_candidate") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "match" ADD CONSTRAINT "match_fk_offer_fkey" FOREIGN KEY ("fk_offer") REFERENCES "offer"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "match" ADD CONSTRAINT "match_fk_user_recruiter_fkey" FOREIGN KEY ("fk_user_recruiter") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -106,13 +106,15 @@ model User {
   createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  candidateProfile CandidateProfile?
-  createdOffers    Offer[]
-  likedOffers      CandidateLikesOffer[]
-  likesGiven       RecruiterLikesCandidate[] @relation("RecruiterLikes")
-  likesReceived    RecruiterLikesCandidate[] @relation("CandidateLikedByRecruiter")
-  recruiterProfile RecruiterProfile?
-  candidateTags    CandidateTag[]
+  candidateProfile   CandidateProfile?
+  createdOffers      Offer[]
+  likedOffers        CandidateLikesOffer[]
+  likesGiven         RecruiterLikesCandidate[] @relation("RecruiterLikes")
+  likesReceived      RecruiterLikesCandidate[] @relation("CandidateLikedByRecruiter")
+  recruiterProfile   RecruiterProfile?
+  candidateTags      CandidateTag[]
+  matchesAsCandidate Match[]                   @relation("MatchCandidate")
+  matchesAsRecruiter Match[]                   @relation("MatchRecruiter")
 
   @@map("user")
 }
@@ -223,6 +225,7 @@ model Offer {
   company        Company               @relation(fields: [companyId], references: [id], onDelete: Cascade)
   offerTags      OfferTag[]
   candidateLikes CandidateLikesOffer[]
+  matches        Match[]
 
   @@map("offer")
 }
@@ -294,4 +297,19 @@ model RecruiterLikesCandidate {
 
   @@id([recruiterUserId, candidateUserId])
   @@map("recruiter_likes_candidate")
+}
+
+model Match {
+  id              Int      @id @default(autoincrement())
+  candidateUserId Int      @map("fk_user_candidate")
+  offerId         Int      @map("fk_offer")
+  recruiterUserId Int?     @map("fk_user_recruiter")
+  matchedAt       DateTime @default(now()) @map("matched_at") @db.Timestamptz(6)
+
+  candidate User  @relation("MatchCandidate", fields: [candidateUserId], references: [id], onDelete: Cascade)
+  offer     Offer @relation(fields: [offerId], references: [id], onDelete: Cascade)
+  recruiter User? @relation("MatchRecruiter", fields: [recruiterUserId], references: [id], onDelete: SetNull)
+
+  @@unique([candidateUserId, offerId])
+  @@map("match")
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -54,8 +54,46 @@ enum TagCategory {
   contract
   theme
   other
+  language
+  benefit
 
   @@map("tag_category")
+}
+
+enum ContractType {
+  CDI
+  CDD
+  ALTERNANCE
+  STAGE
+  FREELANCE
+  INTERIM
+
+  @@map("contract_type")
+}
+
+enum ExperienceLevel {
+  JUNIOR
+  CONFIRME
+  SENIOR
+  EXPERT
+
+  @@map("experience_level")
+}
+
+enum RemotePolicy {
+  ON_SITE
+  HYBRID
+  FULL_REMOTE
+
+  @@map("remote_policy")
+}
+
+enum Availability {
+  IMMEDIATE
+  WITHIN_DELAY
+  SPECIFIC_DATE
+
+  @@map("availability")
 }
 
 model User {
@@ -80,18 +118,31 @@ model User {
 }
 
 model CandidateProfile {
-  id         Int      @id @default(autoincrement())
-  userId     Int      @unique @map("fk_user")
-  prenom     String   @db.VarChar(100)
-  nom        String   @db.VarChar(100)
-  picture    String?  @db.VarChar(255)
-  bio        String?  @db.Text
-  ville      String?  @db.VarChar(100)
-  codePostal String?  @map("code_postal") @db.VarChar(10)
-  latitude   Decimal? @db.Decimal(10, 7)
-  longitude  Decimal? @db.Decimal(10, 7)
-  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt  DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+  id                      Int              @id @default(autoincrement())
+  userId                  Int              @unique @map("fk_user")
+  firstName               String           @map("first_name") @db.VarChar(100)
+  lastName                String           @map("last_name") @db.VarChar(100)
+  picture                 String?          @db.VarChar(255)
+  bio                     String?          @db.Text
+  city                    String?          @db.VarChar(100)
+  postalCode              String?          @map("postal_code") @db.VarChar(10)
+  latitude                Decimal?         @db.Decimal(10, 7)
+  longitude               Decimal?         @db.Decimal(10, 7)
+  desiredJobTitle         String?          @map("desired_job_title") @db.VarChar(255)
+  contractTypes           ContractType[]   @map("contract_types")
+  experienceLevel         ExperienceLevel? @map("experience_level")
+  availability            Availability?
+  availabilityDelayMonths Int?             @map("availability_delay_months")
+  availabilityDate        DateTime?        @map("availability_date") @db.Timestamptz(6)
+  remotePolicy            RemotePolicy?    @map("remote_policy")
+  mobilityRadiusKm        Int?             @map("mobility_radius_km")
+  mobilityNationwide      Boolean?         @map("mobility_nationwide")
+  salaryMin               Int?             @map("salary_min")
+  salaryMax               Int?             @map("salary_max")
+  linkedinUrl             String?          @map("linkedin_url") @db.VarChar(255)
+  cvUrl                   String?          @map("cv_url") @db.VarChar(255)
+  createdAt               DateTime         @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt               DateTime         @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -102,8 +153,8 @@ model RecruiterProfile {
   id        Int      @id @default(autoincrement())
   userId    Int      @unique @map("fk_user")
   companyId Int      @map("fk_company")
-  prenom    String   @db.VarChar(100)
-  nom       String   @db.VarChar(100)
+  firstName String   @map("first_name") @db.VarChar(100)
+  lastName  String   @map("last_name") @db.VarChar(100)
   avatar    String?  @db.VarChar(255)
   jobTitle  String?  @map("job_title") @db.VarChar(150)
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
@@ -117,21 +168,23 @@ model RecruiterProfile {
 
 model Company {
   id          Int          @id @default(autoincrement())
-  nom         String       @db.VarChar(255)
+  name        String       @db.VarChar(255)
   logo        String?      @db.VarChar(255)
-  taille      CompanySize?
+  size        CompanySize?
   sectorId    Int?         @map("fk_sector")
   description String?      @db.Text
   siteUrl     String?      @map("site_url") @db.VarChar(255)
-  ville       String?      @db.VarChar(100)
-  codePostal  String?      @map("code_postal") @db.VarChar(10)
+  coverImage  String?      @map("cover_image") @db.VarChar(255)
+  city        String?      @db.VarChar(100)
+  postalCode  String?      @map("postal_code") @db.VarChar(10)
   latitude    Decimal?     @db.Decimal(10, 7)
   longitude   Decimal?     @db.Decimal(10, 7)
   createdAt   DateTime     @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt   DateTime     @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  recruiter RecruiterProfile[]
-  offers    Offer[]
+  recruiter   RecruiterProfile[]
+  offers      Offer[]
+  companyTags CompanyTag[]
 
   sector Sector? @relation(fields: [sectorId], references: [id], onDelete: SetNull)
 
@@ -148,18 +201,23 @@ model Sector {
 }
 
 model Offer {
-  id          Int         @id @default(autoincrement())
-  companyId   Int         @map("fk_company")
-  createdById Int?        @map("fk_user_created")
-  titre       String      @db.VarChar(255)
-  description String?     @db.Text
-  ville       String?     @db.VarChar(100)
-  codePostal  String?     @map("code_postal") @db.VarChar(10)
-  latitude    Decimal?    @db.Decimal(10, 7)
-  longitude   Decimal?    @db.Decimal(10, 7)
-  statut      OfferStatus @default(draft)
-  createdAt   DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt   DateTime    @updatedAt @map("updated_at") @db.Timestamptz(6)
+  id                 Int              @id @default(autoincrement())
+  companyId          Int              @map("fk_company")
+  createdById        Int?             @map("fk_user_created")
+  title              String           @db.VarChar(255)
+  description        String?          @db.Text
+  city               String?          @db.VarChar(100)
+  postalCode         String?          @map("postal_code") @db.VarChar(10)
+  latitude           Decimal?         @db.Decimal(10, 7)
+  longitude          Decimal?         @db.Decimal(10, 7)
+  contractType       ContractType?    @map("contract_type")
+  minExperienceLevel ExperienceLevel? @map("min_experience_level")
+  remotePolicy       RemotePolicy?    @map("remote_policy")
+  salaryMin          Int?             @map("salary_min")
+  salaryMax          Int?             @map("salary_max")
+  status             OfferStatus      @default(draft)
+  createdAt          DateTime         @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt          DateTime         @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   user           User?                 @relation(fields: [createdById], references: [id], onDelete: SetNull)
   company        Company               @relation(fields: [companyId], references: [id], onDelete: Cascade)
@@ -176,6 +234,7 @@ model Tag {
 
   offerTags     OfferTag[]
   candidateTags CandidateTag[]
+  companyTags   CompanyTag[]
 
   @@map("tag")
 }
@@ -200,6 +259,17 @@ model CandidateTag {
 
   @@id([candidateUserId, tagId])
   @@map("candidate_tag")
+}
+
+model CompanyTag {
+  companyId Int @map("fk_company")
+  tagId     Int @map("fk_tag")
+
+  company Company @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  tag     Tag     @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([companyId, tagId])
+  @@map("company_tag")
 }
 
 model CandidateLikesOffer {


### PR DESCRIPTION
## Résumé

Étend le schéma Prisma pour les informations de profil candidat/recruteur (issue #66) : enums de matching, champs vitrine + matching sur `CandidateProfile` / `Offer` / `Company`, table de jonction `CompanyTag` pour les avantages société. Aligne aussi l'ensemble du schéma sur un nommage anglais.

## Contenu

**Enums**
- Nouveaux : `ContractType`, `ExperienceLevel`, `RemotePolicy`, `Availability`
- `TagCategory` : ajout de `language` (langues candidat) et `benefit` (avantages société)

**CandidateProfile** — `desiredJobTitle`, `contractTypes[]`, `experienceLevel`, `availability` (+ `availabilityDelayMonths`, `availabilityDate`), `remotePolicy`, `mobilityRadiusKm`, `mobilityNationwide`, `salaryMin/Max`, `linkedinUrl`, `cvUrl`

**Offer** — `contractType`, `minExperienceLevel`, `remotePolicy`, `salaryMin/Max`

**Company** — `coverImage` + table `CompanyTag` (avantages = tags catégorie `benefit`)

**Nommage** — tout le schéma passe en anglais, socle inclus (`titre`→`title`, `ville`→`city`, `prenom`→`first_name`, `statut`→`status`, `taille`→`size`, `code_postal`→`postal_code`…).

## Décisions clés

- Identifiants (champs/colonnes) **en anglais** ; **valeurs d'enum métier gardées en codes du marché français** (`CDI/CDD/ALTERNANCE/STAGE/FREELANCE/INTERIM`, `TPE/PME/ETI/GE`, `CONFIRME`) — classifications standard sans équivalent anglais fidèle.
- **Disponibilité découplée** : le délai est une donnée (`availabilityDelayMonths`), pas une valeur d'enum — changer « sous 3 mois » → « sous 2 mois » ne nécessite aucune migration.
- **Liens candidat = LinkedIn uniquement** (champ scalaire `linkedinUrl`), pas de table dédiée.
- `ExperienceLevel` **sans** `DEBUTANT`.
- **Champs matching nullable** en base : l'obligation est portée par la validation applicative (onboarding en wizard multi-étapes).

## Migration

`20260719194422_add_profile_and_english_naming` — testée en local (base en sync, client Prisma régénéré, `prisma validate` OK). Les renommages sont générés en `DROP`+`ADD` : **sans risque, aucune donnée en local ni en preprod** (confirmé).

## Hors périmètre

- Stockage fichier pour `cvUrl` / `coverImage` (bucket ou volume) — dépendance infra à cadrer.
- Table `match` (socle matching) — sera ajoutée séparément.

Related to #66
