### PR TITLE
feat(#31): add missing match table

### DIFF
--- a/backend/prisma/migrations/20260719205910_add_match_table/migration.sql
+++ b/backend/prisma/migrations/20260719205910_add_match_table/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "match" (
+    "id" SERIAL NOT NULL,
+    "fk_user_candidate" INTEGER NOT NULL,
+    "fk_offer" INTEGER NOT NULL,
+    "fk_user_recruiter" INTEGER,
+    "matched_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "match_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "match_fk_user_candidate_fk_offer_key" ON "match"("fk_user_candidate", "fk_offer");
+
+-- AddForeignKey
+ALTER TABLE "match" ADD CONSTRAINT "match_fk_user_candidate_fkey" FOREIGN KEY ("fk_user_candidate") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "match" ADD CONSTRAINT "match_fk_offer_fkey" FOREIGN KEY ("fk_offer") REFERENCES "offer"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "match" ADD CONSTRAINT "match_fk_user_recruiter_fkey" FOREIGN KEY ("fk_user_recruiter") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -106,13 +106,15 @@ model User {
   createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  candidateProfile CandidateProfile?
-  createdOffers    Offer[]
-  likedOffers      CandidateLikesOffer[]
-  likesGiven       RecruiterLikesCandidate[] @relation("RecruiterLikes")
-  likesReceived    RecruiterLikesCandidate[] @relation("CandidateLikedByRecruiter")
-  recruiterProfile RecruiterProfile?
-  candidateTags    CandidateTag[]
+  candidateProfile   CandidateProfile?
+  createdOffers      Offer[]
+  likedOffers        CandidateLikesOffer[]
+  likesGiven         RecruiterLikesCandidate[] @relation("RecruiterLikes")
+  likesReceived      RecruiterLikesCandidate[] @relation("CandidateLikedByRecruiter")
+  recruiterProfile   RecruiterProfile?
+  candidateTags      CandidateTag[]
+  matchesAsCandidate Match[]                   @relation("MatchCandidate")
+  matchesAsRecruiter Match[]                   @relation("MatchRecruiter")
 
   @@map("user")
 }
@@ -223,6 +225,7 @@ model Offer {
   company        Company               @relation(fields: [companyId], references: [id], onDelete: Cascade)
   offerTags      OfferTag[]
   candidateLikes CandidateLikesOffer[]
+  matches        Match[]
 
   @@map("offer")
 }
@@ -294,4 +297,19 @@ model RecruiterLikesCandidate {
 
   @@id([recruiterUserId, candidateUserId])
   @@map("recruiter_likes_candidate")
+}
+
+model Match {
+  id              Int      @id @default(autoincrement())
+  candidateUserId Int      @map("fk_user_candidate")
+  offerId         Int      @map("fk_offer")
+  recruiterUserId Int?     @map("fk_user_recruiter")
+  matchedAt       DateTime @default(now()) @map("matched_at") @db.Timestamptz(6)
+
+  candidate User  @relation("MatchCandidate", fields: [candidateUserId], references: [id], onDelete: Cascade)
+  offer     Offer @relation(fields: [offerId], references: [id], onDelete: Cascade)
+  recruiter User? @relation("MatchRecruiter", fields: [recruiterUserId], references: [id], onDelete: SetNull)
+
+  @@unique([candidateUserId, offerId])
+  @@map("match")
 }


### PR DESCRIPTION
## Summary

Ajoute la **table de match** manquante au schéma (migration `20260719205910_add_match_table` + `schema.prisma`). Ticket #31.

## Why

La table de match manquait au modèle de données. Elle matérialise le match (like réciproque candidat ↔ offre/recruteur) nécessaire au reste du parcours.

## How

- Nouvelle migration Prisma `20260719205910_add_match_table`.
- Mise à jour de `schema.prisma` en conséquence.

## Note

> ⚠️ **Base = `feat/66-schema-profil`** (le commit est empilé sur le schéma #66). À **rebaser / retarget sur `preprod` une fois #66 (PR #75) mergé** — GitHub le fera automatiquement. Le diff ne montre donc que la table de match.
>
> Ce commit avait initialement atterri par erreur sur `feat/73` (working tree partagé) ; il a été isolé ici pour garder chaque PR sur son ticket.
