### PR TITLE
chore(deps): exclure les montées de version majeure de Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
     groups:
       # Framework packages move together; separate PRs for @nestjs/* would
       # conflict with each other on the lockfile and none would merge.
@@ -41,6 +45,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
     groups:
       react:
         patterns:
@@ -61,24 +69,44 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: docker
     directory: /backend
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: docker
     directory: /clientApp
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
 
   # compose.yml at the repository root.
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: docker
     directory: /docker
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## Contexte

Dependabot ouvrait des PR de montée de version majeure sur tous les écosystèmes : `typescript` 5 → 7, `eslint` 9 → 10, `jsdom` 29 → 30, `@sentry/cli` 2 → 3, `@types/node` 24 → 26, et trois actions GitHub (`setup-node` 5 → 7, `upload-artifact` 4 → 7, `sonarqube-scan-action` 6 → 8). Ces PR ne sont jamais mergeables en l'état : une majeure demande une lecture du changelog et souvent une adaptation du code, ce qui n'a rien à voir avec le flux d'entretien hebdomadaire auquel Dependabot sert.

## Ce que fait la PR

Ajout d'une condition `ignore` sur les 7 entrées `updates` :

```yaml
ignore:
  - dependency-name: '*'
    update-types:
      - version-update:semver-major
```

`ignore` est évalué avant le regroupement, donc les groupes existants (`nestjs`, `prisma`, `sentry`, `react`) ne remontent plus de majeure non plus. Le `update-types: [minor, patch]` du groupe `dev-tooling` devient redondant mais reste en place comme documentation d'intention.

Aucune suppression, 28 lignes ajoutées.

## Effet attendu

- Les minor et patch continuent d'arriver normalement, groupés comme avant.
- Les majeures ne génèrent plus de PR : elles se traitent à la main, quand on décide de les traiter.
- Les 8 PR de majeures actuellement ouvertes sont fermées séparément.

## Point de vigilance

Une condition `ignore` s'applique aussi aux *security updates*. Si un CVE n'a de correctif que dans une majeure, aucune PR ne sera ouverte automatiquement — l'alerte reste visible dans l'onglet Security du repo et devra être traitée manuellement.
