### PR TITLE
chore(ci): bump actions/upload-artifact to v7 for the Node 24 runtime

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -108,7 +108,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: backend-coverage


### PR DESCRIPTION
## Summary

Bumps `actions/upload-artifact` from `v4` to `v7` in the CI Backend workflow (single occurrence, `Upload coverage` step).

## Why

GitHub deprecated the Node.js 20 action runtime on 2025-09-19. `actions/upload-artifact@v4` declares `runs.using: node20`, so every CI Backend run emitted:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@v4.

This is about the runtime of the action itself, not the project's Node version — the `setup-node` steps have no bearing on it.

## How

`v7.0.1` is the latest release. The upgrade path is safe for our usage (`name` + `path` + `if-no-files-found`):

- **v5** — preliminary Node 24 support
- **v6** — switches the runtime to `node24` (requires runner >= 2.327.1, satisfied by `ubuntu-latest`)
- **v7** — ESM migration plus an opt-in `archive: false` for unzipped single-file uploads; no change to the existing inputs

Every other action in the three workflows is already on a Node 24 runtime (`checkout@v7`, `setup-node@v5`, `sonarqube-scan-action@v6`), so this was the last offender.

## Todos

- [ ] Confirm the deprecation warning is gone from the CI Backend run on this PR
